### PR TITLE
karpenter version updated in eks-blueprints-addons from 0.32.1 to 0.37

### DIFF
--- a/add-ons/karpenter/Chart.yaml
+++ b/add-ons/karpenter/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: '1.0'
 
 dependencies:
   - name: karpenter
-    version: v0.32.1
+    version: v0.37.0
     repository: oci://public.ecr.aws/karpenter


### PR DESCRIPTION
Karpenter version has been updated from `v0.32.1` to `0.37` - which is compatible with EKS cluster `1.30`

In Production ArgoCd, `automated syncPolicy` for Karpenter application has been disabled. This change should only been applicable to the `development` cluster.