### PR TITLE
reverting to older version - fixing error - public repo not found oci…

### DIFF
--- a/add-ons/karpenter/Chart.yaml
+++ b/add-ons/karpenter/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: '1.0'
 
 dependencies:
   - name: karpenter
-    version: v0.37.0
+    version: v0.36.2
     repository: oci://public.ecr.aws/karpenter


### PR DESCRIPTION
reverting version to older 0.36.2