### PR TITLE
For 6116 karpenter version upgrade

### DIFF
--- a/add-ons/karpenter/Chart.yaml
+++ b/add-ons/karpenter/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: '1.0'
 
 dependencies:
   - name: karpenter
-    version: v0.36.2
+    version: v0.32.1
     repository: oci://public.ecr.aws/karpenter


### PR DESCRIPTION
Production is still updating from the HEAD in argocd, despite disabling autosync. Reverting to 0.32.1